### PR TITLE
Python 3.6 compatibility and time options 

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ from setuptools import setup, find_packages
 
 os.environ['GIT_SSL_NO_VERIFY'] = 'true'
 
-__version__ = '1.1.1'
+__version__ = '1.1.2'
 
 setup(
     name='catfishq',


### PR DESCRIPTION
Included --print-start-time, min as option for --start-time, made compatibel with Python 3.6