### PR TITLE
Adding a min_sequencing_time option

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ from setuptools import setup, find_packages
 
 os.environ['GIT_SSL_NO_VERIFY'] = 'true'
 
-__version__ = '1.1.2'
+__version__ = '1.1.3'
 
 setup(
     name='catfishq',


### PR DESCRIPTION
sequencing_time was replaced with max_sequencing_time

Maybe important: I changed the condition so a read starting exactly at the max_sequencing_time is still included
Before: start < max_start_time 
Now: start <= max_start_time
